### PR TITLE
Fixed Atom feed URL for Gilles Lenfant's blog

### DIFF
--- a/feeds.cfg
+++ b/feeds.cfg
@@ -248,7 +248,7 @@ name = Javier Mansilla
 link = http://pyyou.wordpress.com/
 name = Youenn Boussard
 
-[http://glenfant.wordpress.com/atom]
+[http://glenfant.wordpress.com/feed/]
 name = Gilles Lenfant
 link = http://glenfant.wordpress.com/
 


### PR DESCRIPTION
to http://glenfant.wordpress.com/feed/
