### PR TITLE
Preventing future blog posts clogging up planet.plone.org

### DIFF
--- a/etc/venus.cfg.in
+++ b/etc/venus.cfg.in
@@ -16,3 +16,4 @@ output_theme    = ${buildout:directory}/theme
 output_dir      = ${buildout:htdocs-directory}
 cache_directory = ${buildout:directory}/var/cache
 items_per_page  = 15
+future_dates    = ignore_date


### PR DESCRIPTION
See trac ticket:
https://dev.plone.org/ticket/13194

There is a blog post clogging up planet.plone.org

I have added a setting to Venus config in the planet.plone.org buildout to prevent this. It is untested since the buildout wouldn't build on my machine but I cannot see the edit do any harm.

I have set it to "ignore_date", see docs below from Venus:

"'future_dates' allows you to specify how to deal with dates which are in the future.
'ignore_date' will cause the date to be ignored (and will therefore default to the time the entry was first seen) until the feed is updated and the time indicated is past, at which point the entry will be updated with the new date.
'ignore_entry' will cause the entire entry containing the future date to be ignored until the date is past.
Anything else (i.e.. the default) will leave the date as is, causing the entries that contain these dates sort to the top of the planet until the time passes."
