### PR TITLE
add 4teamwork blog to feeds.cfg

### DIFF
--- a/feeds.cfg
+++ b/feeds.cfg
@@ -648,4 +648,6 @@ link = http://cosent.nl/en/blog
 name = Paul Roeland
 link = http://polyrambling.tumblr.com/
 
-
+[http://www.4teamwork.ch/live/rss_blog_view?tag=planet+plone]
+name = 4teamwork
+link = http://www.4teamwork.ch/live


### PR DESCRIPTION
I added a filtered RSS feed from the 4teamwork blog to the `feeds.cfg`. The entries on the blog up until now are written in German so the current filtered feed does not contain any entries at the moment. As we want to write English Plone related posts it would be great to have them on http://planet.plone.org/

Feed: http://www.4teamwork.ch/live/rss_blog_view?tag=planet+plone
Blog: http://www.4teamwork.ch/live
