### PR TITLE
move 4teamwork feed to specific Devblog

### DIFF
--- a/feeds.cfg
+++ b/feeds.cfg
@@ -648,6 +648,6 @@ link = http://cosent.nl/en/blog
 name = Paul Roeland
 link = http://polyrambling.tumblr.com/
 
-[http://www.4teamwork.ch/live/rss_blog_view?tag=planet+plone]
+[http://feeds.feedburner.com/4teamworkDevblog]
 name = 4teamwork
 link = http://www.4teamwork.ch/live


### PR DESCRIPTION
Hey guys,

We decided to move our technical blog to a separate site. It would be awesome if you could update the feed.

Thanks in advance :yellow_heart: 
