### PR TITLE
Switched my url to use the blogger rss instead of the default atom feed

### DIFF
--- a/feeds.cfg
+++ b/feeds.cfg
@@ -23,7 +23,7 @@ link = http://www.makina-corpus.com
 name = PloneConf 2013
 link = http://www.ploneconf.org
 
-[http://pigeonflight.blogspot.com/feeds/posts/default/-/plone]
+[http://pigeonflight.blogspot.com/feeds/posts/default/-/plone?alt=rss]
 name = David "Pigeonflight" Bain
 link = http://pigeonflight.blogspot.com
 


### PR DESCRIPTION
This should fix the blogger "bug" where updated posts get bumped to the top of the Planet Plone feed. If this works, I'll encourage others to do the same