### PR TITLE
Update niteoweb.com feed

### DIFF
--- a/feeds.cfg
+++ b/feeds.cfg
@@ -549,7 +549,7 @@ link = http://eestec.net/news-and-offers/planet.plone.org
 name = unweb.me 
 link = https://unweb.me/blog
 
-[http://www.niteoweb.com/search_rss?Subject=Plone&sort_on=effective&portal_type=Blog%20Entry]
+[http://blog.niteoweb.com/tag/plone/feed/]
 name = Niteoweb
 link = http://www.niteoweb.com/blog
 


### PR DESCRIPTION
Moved blog from niteoweb.com/blog to blog.niteoweb.com.