### PR TITLE
Fix the url to Maurits' blog.

### DIFF
--- a/planet/planet.ini
+++ b/planet/planet.ini
@@ -112,9 +112,8 @@ name = Starzel.de
 #face = images/heads/starzel_logo.png
 face = https://pbs.twimg.com/profile_images/1619803441/philip_80x80.jpg
 
-[http://maurits.vanrees.org/weblog/topics/plone/@@atom.xml]
+[https://maurits.vanrees.org/weblog/plone-1/atom.xml]
 name = Maurits van Rees
-#fasname = admin
 face = https://pbs.twimg.com/profile_images/555124853938745346/OFilNfOj_80x80.jpeg
 
 [http://polyrambling.tumblr.com/rss]


### PR DESCRIPTION
The old http one is redirected automatically, so should still work, but I don't see my posts from this week. So let's use the proper url.